### PR TITLE
remove Notice Type display, while DMCA bug exists

### DIFF
--- a/app/views/notices/show.html.erb
+++ b/app/views/notices/show.html.erb
@@ -46,11 +46,6 @@
       <h2>Re: <%= subject(@notice) %></h2>
       <p class="source">Sent via: <%= sent_via(@notice) %></p>
 	  
-      <dl class="notice-type">
-        <dt class="label">Notice Type:</dt>
-        <dd class="field"><%= @notice.type.titleize %></dd>
-      </dl>
-
       <dl class="action-taken">
         <dt class="label">Action taken:</dt>
         <dd class="field"><%= @notice.action_taken %></dd>


### PR DESCRIPTION
until we can reassign non-DMCA notices out of this type, remove the type label from display