### PR TITLE
Limiting requests

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -33,6 +33,7 @@ gem 'activerecord-import'
 gem 'html2md'
 gem 'mysql2'
 gem 'ruby-progressbar'
+gem 'rack-throttle'
 
 group :assets do
   gem 'coffee-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -191,6 +191,8 @@ GEM
       rack
     rack-test (0.6.2)
       rack (>= 1.0)
+    rack-throttle (0.4.0)
+      rack (>= 1.0.0)
     rails (3.2.18)
       actionmailer (= 3.2.18)
       actionpack (= 3.2.18)
@@ -348,6 +350,7 @@ DEPENDENCIES
   paperclip!
   pg
   pry-rails
+  rack-throttle
   rails (~> 3.2.11)
   rails_admin (~> 0.4.8)
   rb-inotify

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -34,6 +34,10 @@ class Ability
     if user.has_role?(Role.super_admin)
       can :manage, :all
     end
+    
+    if user.has_role?(Role.researcher)
+      can :read, Notice
+    end
   end
 
   def grant_admin_access

--- a/app/models/role.rb
+++ b/app/models/role.rb
@@ -5,6 +5,7 @@ class Role < ActiveRecord::Base
     publisher
     admin
     super_admin
+    researcher
   )
 
   NAMES.each do |name|

--- a/config/application.rb
+++ b/config/application.rb
@@ -7,6 +7,8 @@ require "action_mailer/railtie"
 require "active_resource/railtie"
 require "sprockets/railtie"
 # require "rails/test_unit/railtie"
+require 'gdbm'
+require 'rack/throttle'
 
 if defined?(Bundler)
   # If you precompile assets before deploying to production, use this line
@@ -78,5 +80,10 @@ module Chill
     config.assets.version = '1.0'
 
     config.middleware.insert_before ActionDispatch::ParamsParser, "CatchJsonParsingErrors"
+    
+    #config.middleware.use Rack::Throttle::Minute, :max => 3, :cache => GDBM.new('tmp/throttle.db')
+    #Set up rate limiting
+    config.require "custom_limiter"
+    config.middleware.use CustomLimiter, :max => 3, :cache => GDBM.new('tmp/throttle.db')
   end
 end

--- a/lib/custom_limiter.rb
+++ b/lib/custom_limiter.rb
@@ -4,11 +4,13 @@ class CustomLimiter < Rack::Throttle::Minute
     if request.media_type == "application/json"
       if request.env["HTTP_AUTHENTICATION_TOKEN"].nil?
         request.GET[:per_page] = 25
+        request.GET[:page] = 1
         super
       elsif User.find_by_authentication_token(request.env["HTTP_AUTHENTICATION_TOKEN"]).has_role?(Role.researcher) 
         true
       else
         request.GET[:per_page] = 25
+        request.GET[:page] = 1
         super  
       end  
     else 

--- a/lib/custom_limiter.rb
+++ b/lib/custom_limiter.rb
@@ -1,0 +1,18 @@
+class CustomLimiter < Rack::Throttle::Minute
+  def allowed?(request)
+    #path_info = Rails.application.routes.recognize_path request.url rescue {}
+    if request.media_type == "application/json"
+      if request.env["HTTP_AUTHENTICATION_TOKEN"].nil?
+        request.GET[:per_page] = 25
+        super
+      elsif User.find_by_authentication_token(request.env["HTTP_AUTHENTICATION_TOKEN"]).has_role?(Role.researcher) 
+        true
+      else
+        request.GET[:per_page] = 25
+        super  
+      end  
+    else 
+      true
+    end
+  end
+end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -207,6 +207,10 @@ FactoryGirl.define do
     trait :with_entity do
       entity
     end
+    
+    trait :researcher do
+      roles { [Role.researcher] }
+    end
   end
 
   factory :relevant_question do


### PR DESCRIPTION
In a nutshell:

- added gem rack-throttle
- added "researcher" role with the ability to read Notice
- created lib/custom_limiter.rb to check to see if a requestor has an API key and a role of "researcher" otherwise throttle rate at 3 requests per minute and only 25 records per request.