### PR TITLE
Remove requirement that URL of copyrighted work be included in web form.

### DIFF
--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -9,7 +9,7 @@ class Work < ActiveRecord::Base
   has_and_belongs_to_many :infringing_urls
   has_and_belongs_to_many :copyrighted_urls
 
-  accepts_nested_attributes_for :infringing_urls, :copyrighted_urls
+  accepts_nested_attributes_for :infringing_urls, :copyrighted_urls, :reject_if => proc { |attributes| attributes['url'].blank? }
   validates_associated :infringing_urls, :copyrighted_urls
 
   # Similar to the hack in EntityNoticeRole, because all validations are

--- a/app/views/notices/_url_input_group.html.erb
+++ b/app/views/notices/_url_input_group.html.erb
@@ -5,9 +5,18 @@
   data: { target: url_input_notices_url(type: notice.class, url_type: assoc, index: index) }
 ) %>
 <%= works_form.simple_fields_for(assoc) do |urls_form| %>
-  <%= urls_form.input(
-    :url,
-    label: label_for_url_input(assoc, notice),
-    placeholder: "http://"
-  ) %>
+  <% if assoc == :copyrighted_urls %>
+	  <%= urls_form.input(
+	    :url,
+	    label: label_for_url_input(assoc, notice),
+	    placeholder: "http://",
+	    required: false 
+	  ) %>
+	<% else %>
+		<%= urls_form.input(
+		  :url,
+		  label: label_for_url_input(assoc, notice),
+		  placeholder: "http://"
+		) %>
+	<% end %>
 <% end %>

--- a/spec/views/notices/new.html.erb_spec.rb
+++ b/spec/views/notices/new.html.erb_spec.rb
@@ -9,6 +9,22 @@ describe 'notices/new.html.erb' do
     expect(rendered).to have_css 'form'
   end
 
+  it "should not require copyrighted urls" do
+    assign(:notice, create(:dmca, :with_copyrighted_urls))
+
+    render
+
+    expect(rendered).to have_content("Original Work URL")
+  end
+
+  it "should require infringing urls" do
+    assign(:notice, create(:dmca, :with_infringing_urls))
+
+    render
+
+    expect(rendered).to have_content("Allegedly Infringing URL *")
+  end
+
   Notice.type_models.each do |model|
     context "country selectors in \"#{model.label}\" notices" do
       it "use ISO country codes" do


### PR DESCRIPTION
This is the fix for Bug #8341. After implementation the DMCA notice submission form should no longer require that a URL be submitted for the original work.