### PR TITLE
Change the Dmca class to DMCA.

### DIFF
--- a/app/controllers/notices_controller.rb
+++ b/app/controllers/notices_controller.rb
@@ -156,11 +156,11 @@ class NoticesController < ApplicationController
     if notice_type < Notice
       notice_type
     else
-      Dmca
+      DMCA
     end
 
   rescue NameError
-    Dmca
+    DMCA
   ensure
     params.delete(:type)
   end

--- a/app/helpers/notices_helper.rb
+++ b/app/helpers/notices_helper.rb
@@ -54,7 +54,7 @@ module NoticesHelper
     case url_type
     when :infringing_urls
       case notice
-      when ::Dmca, ::Trademark
+      when ::DMCA, ::Trademark
         "Allegedly Infringing URL"
       when ::PrivateInformation
         "URL with private information"
@@ -69,7 +69,7 @@ module NoticesHelper
       end
     when :copyrighted_urls
       case notice
-      when ::Dmca, ::Other
+      when ::DMCA, ::Other
         "Original Work URL"
       when ::LawEnforcementRequest
         "URL of original work"

--- a/app/models/dmca.rb
+++ b/app/models/dmca.rb
@@ -1,4 +1,4 @@
-class Dmca < Notice
+class DMCA < Notice
 
   define_elasticsearch_mapping
 

--- a/app/models/notice.rb
+++ b/app/models/notice.rb
@@ -59,7 +59,7 @@ class Notice < ActiveRecord::Base
   OTHER_TOPIC = "Uncategorized"
 
   TYPES_TO_TOPICS = {
-    'Dmca'                  => "Copyright",
+    'DMCA'                  => "Copyright",
     'Trademark'             => "Trademark",
     'Defamation'            => "Defamation",
     'CourtOrder'            => "Court Orders",

--- a/config/initializers/inflections.rb
+++ b/config/initializers/inflections.rb
@@ -13,3 +13,6 @@
 # ActiveSupport::Inflector.inflections do |inflect|
 #   inflect.acronym 'RESTful'
 # end
+ActiveSupport::Inflector.inflections do |inflect|
+  inflect.acronym 'DMCA'
+end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -29,7 +29,7 @@ en:
         title: 'Redact queue'
 
   type_descriptions:
-    Dmca:
+    DMCA:
       'Is someone complaining that images, text, video, or other content found online infringe their copyrights?'
 
     Trademark:

--- a/doc/api_documentation.mkd
+++ b/doc/api_documentation.mkd
@@ -26,7 +26,7 @@ Chilling Effects staff for your authentication token.
 | Field                              | Type               | Description
 | ---                                | ---                | ---
 | `title`                            | string             | Required
-| `type`                             | string             | Required: one of 'CourtOrder', 'DataProtection', 'Defamation', 'Dmca', 'LawEnforcementRequest', 'Other', 'PrivateInformation', or 'Trademark'
+| `type`                             | string             | Required: one of 'CourtOrder', 'DataProtection', 'Defamation', 'DMCA', 'LawEnforcementRequest', 'Other', 'PrivateInformation', or 'Trademark'
 | `subject`                          | string             | Optional. A short description of the notice and its contents. E.g. "DMCA Notice Regarding Photographs" or "Court Order From Paris Court Re: Hate Speech"
 | `body`                             | string             | Optional. Use this field to submit any additional text provided by the complainant that does not belong properly in any other notice field.  No sensitive information or PII should be included here. E.g., Phone numbers, street addresses, allegedly defamatory language, etc.
 | `date_sent`                        | string             | Any parseable time value, e.g. "2013-05-21", "2013-05-21 10:01:01 -04:00"
@@ -206,7 +206,7 @@ curl -v -H "Accept: application/json" -H "Content-type: application/json" 'https
   "authentication_token": "abc123",
   "notice": {
     "title": "DMCA (Copyright) Complaint to Google",
-    "type": "Dmca",
+    "type": "DMCA",
     "subject": "Infringement Notfication via Blogger Complaint",
     "date_sent": "2013-05-22",
     "date_received": "2013-05-23",
@@ -281,7 +281,7 @@ curl -v -H "Accept: application/json" -H "Content-type: application/json" 'https
   "authentication_token": "abc123",
   "notice": {
     "title": "DMCA (Copyright) Complaint to Google",
-    "type": "Dmca",
+    "type": "DMCA",
     "subject": "Infringement Notfication via Blogger Complaint",
     "date_sent": "2013-05-22",
     "date_received": "2013-05-23",
@@ -706,7 +706,7 @@ curl -H "Accept: application/json" -H "Content-type: application/json" 'https://
   "notices": [
     {
       "id": "491",
-      "type": "Dmca",
+      "type": "DMCA",
       "title": "Star Wars",
       "body": null,
       "date_received": null,

--- a/lib/ingestor.rb
+++ b/lib/ingestor.rb
@@ -4,8 +4,8 @@ end
 
 module Ingestor
   ImportDispatcher.register(Importer::Google)
-  ImportDispatcher.register(Importer::GoogleSecondary::DmcaParser)
-  ImportDispatcher.register(Importer::GoogleSecondary::EbDmcaParser)
+  ImportDispatcher.register(Importer::GoogleSecondary::DMCAParser)
+  ImportDispatcher.register(Importer::GoogleSecondary::EbDMCAParser)
   ImportDispatcher.register(Importer::GoogleSecondary::BloggerParser)
   ImportDispatcher.register(Importer::GoogleSecondary::OtherParser)
   ImportDispatcher.register(Importer::Twitter)

--- a/lib/ingestor/importer/base.rb
+++ b/lib/ingestor/importer/base.rb
@@ -38,7 +38,7 @@ module Ingestor
       def initialize(original_file_paths, supporting_file_paths = nil)
         @original_file_paths = fix_paths(original_file_paths)
         @supporting_file_paths = fix_paths(supporting_file_paths)
-        @notice_type = Dmca
+        @notice_type = DMCA
       end
 
       def entities

--- a/lib/ingestor/importer/google_secondary/dmca_parser.rb
+++ b/lib/ingestor/importer/google_secondary/dmca_parser.rb
@@ -3,7 +3,7 @@ require 'ingestor/importer/base'
 module Ingestor
   module Importer
     module GoogleSecondary
-      class DmcaParser < Base
+      class DMCAParser < Base
 
         handles_content(/IssueType:\s?lr_dmca/m)
 

--- a/lib/ingestor/importer/google_secondary/eb_dmca_parser.rb
+++ b/lib/ingestor/importer/google_secondary/eb_dmca_parser.rb
@@ -3,7 +3,7 @@ require 'ingestor/importer/base'
 module Ingestor
   module Importer
     module GoogleSecondary
-      class EbDmcaParser < Base
+      class EbDMCAParser < Base
 
         handles_content(/IssueType:\s?eb_dmca/m)
 

--- a/lib/tasks/chillingeffects.rake
+++ b/lib/tasks/chillingeffects.rake
@@ -361,4 +361,14 @@ namespace :chillingeffects do
     puts "Broad query: #{broad}"
     puts "Difference of: #{broad - narrow}"
   end
+
+  desc "Reassign Dmca Notices to DMCA notices"
+  task up_dmca_migration: :environment do
+    Notice.where(type: 'Dmca').update_all(type: 'DMCA')
+  end
+
+  desc "Reassign DMCA Notices to Dmca notices"
+  task down_dmca_migration: :environment do
+    Notice.where(type: 'DMCA').update_all(type: 'Dmca')
+  end
 end

--- a/spec/controllers/notices_controller_spec.rb
+++ b/spec/controllers/notices_controller_spec.rb
@@ -75,9 +75,9 @@ describe NoticesController do
         @notice_params = HashWithIndifferentAccess.new(title: "A title")
       end
 
-      it "initializes a Dmca by default from params" do
+      it "initializes a DMCA by default from params" do
         SubmitNotice.should_receive(:new).
-          with(Dmca, @notice_params).
+          with(DMCA, @notice_params).
           and_return(@submit_notice)
 
         post :create, notice: @notice_params
@@ -91,12 +91,12 @@ describe NoticesController do
         post :create, notice: @notice_params.merge(type: 'trademark')
       end
 
-      it "defaults to Dmca if the type is missing or invalid" do
+      it "defaults to DMCA if the type is missing or invalid" do
         invalid_types = ['', 'FlimFlam', 'Object', 'User', 'Hash']
 
         SubmitNotice.should_receive(:new).
           exactly(5).times.
-          with(Dmca, @notice_params).
+          with(DMCA, @notice_params).
           and_return(@submit_notice)
 
         invalid_types.each do |invalid_type|
@@ -179,7 +179,7 @@ describe NoticesController do
     private
 
     def stub_submit_notice
-      SubmitNotice.new(Dmca, {}).tap do |submit_notice|
+      SubmitNotice.new(DMCA, {}).tap do |submit_notice|
         submit_notice.stub(:submit).and_return(true)
         SubmitNotice.stub(:new).and_return(submit_notice)
       end

--- a/spec/integration/imports_existing_data_as_csv_spec.rb
+++ b/spec/integration/imports_existing_data_as_csv_spec.rb
@@ -14,7 +14,7 @@ feature "Importing CSV" do
       @secondary_dmca_notice,
       @twitter_notice,
       @primary_notice_without_data
-    ) = Dmca.order(:id)
+    ) = DMCA.order(:id)
 
     (
       @secondary_other_notice,

--- a/spec/integration/page_titles_spec.rb
+++ b/spec/integration/page_titles_spec.rb
@@ -54,7 +54,7 @@ feature 'Page titles' do
     click_on 'DMCA'
 
     # submission form itself
-    expect(page).to have_exact_title('Dmca :: Report a Demand :: Chilling Effects')
+    expect(page).to have_exact_title('DMCA :: Report a Demand :: Chilling Effects')
     expect(page).to have_heading('Report a Demand')
   end
 

--- a/spec/integration/submit_notice_via_web_spec.rb
+++ b/spec/integration/submit_notice_via_web_spec.rb
@@ -228,7 +228,7 @@ feature "notice submission" do
   end
 
   scenario "a form articulates its required fields correctly" do
-    visit "/notices/new?type=Dmca"
+    visit "/notices/new?type=DMCA"
 
     within('form#new_notice') do
       expect(page).to have_css("input##{works_copyrighted_url_id}.required")
@@ -237,7 +237,7 @@ feature "notice submission" do
   end
 
   scenario "submitting a notice without required fields present" do
-    visit "/notices/new?type=Dmca"
+    visit "/notices/new?type=DMCA"
 
     click_on "Submit"
 

--- a/spec/lib/ingestor/importer/google_secondary/dmca_parser_spec.rb
+++ b/spec/lib/ingestor/importer/google_secondary/dmca_parser_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 require 'ingestor'
 
-describe Ingestor::Importer::GoogleSecondary::DmcaParser do
+describe Ingestor::Importer::GoogleSecondary::DMCAParser do
 
   it "has a default_recipient" do
     expect(described_class.new('').default_recipient).to eq 'Google, Inc.'

--- a/spec/lib/ingestor/importer/google_secondary/eb_dmca_parser_spec.rb
+++ b/spec/lib/ingestor/importer/google_secondary/eb_dmca_parser_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 require 'ingestor'
 
-describe Ingestor::Importer::GoogleSecondary::EbDmcaParser do
+describe Ingestor::Importer::GoogleSecondary::EbDMCAParser do
 
   it "has a default_recipient" do
     expect(described_class.new('').default_recipient).to eq 'Google, Inc.'

--- a/spec/lib/ingestor/importer/google_spec.rb
+++ b/spec/lib/ingestor/importer/google_spec.rb
@@ -21,8 +21,8 @@ describe Ingestor::Importer::Google do
   end
 
   context "#notice_type" do
-    it "should be Dmca" do
-      expect(described_class.new('').notice_type).to eq Dmca
+    it "should be DMCA" do
+      expect(described_class.new('').notice_type).to eq DMCA
     end
   end
 

--- a/spec/lib/ingestor/legacy_spec.rb
+++ b/spec/lib/ingestor/legacy_spec.rb
@@ -9,7 +9,7 @@ describe Ingestor::Legacy do
 
     @attribute_mapper = double("AttributeMapper")
     @attribute_mapper.stub(:exclude?).and_return(false)
-    @attribute_mapper.stub(:notice_type).and_return(Dmca)
+    @attribute_mapper.stub(:notice_type).and_return(DMCA)
     @attribute_mapper.stub(:mapped).and_return({})
     described_class::AttributeMapper.stub(:new).and_return(@attribute_mapper)
   end
@@ -22,13 +22,13 @@ describe Ingestor::Legacy do
   end
 
   it "attempts to find a notice by original_notice_id before importing" do
-    dmca = Dmca.new
+    dmca = DMCA.new
 
     existing_notice_ids.each do |original_notice_id|
       Notice.should_receive(:where).with(original_notice_id: original_notice_id).once.and_return(dmca)
     end
 
-    Dmca.should_not_receive(:create!)
+    DMCA.should_not_receive(:create!)
 
     importer.import
   end

--- a/spec/models/dmca_spec.rb
+++ b/spec/models/dmca_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe Dmca do
+describe DMCA do
   before do
     @notice_topics = create_list(:notice_topic, 8)
   end
@@ -8,7 +8,7 @@ describe Dmca do
   it { should validate_presence_of :works }
   it { should validate_presence_of :entity_notice_roles }
   it { should ensure_inclusion_of(:language).in_array(Language.codes) }
-  it { should ensure_inclusion_of(:action_taken).in_array(Dmca::VALID_ACTIONS).allow_blank }
+  it { should ensure_inclusion_of(:action_taken).in_array(DMCA::VALID_ACTIONS).allow_blank }
 
   context 'automatic validations' do
     it { should ensure_length_of(:title).is_at_most(255) }
@@ -28,7 +28,7 @@ describe Dmca do
   it_behaves_like "an object tagged in the context of", "jurisdiction"
 
   it "leaves no action taken as unspecified" do
-    notice = Dmca.new
+    notice = DMCA.new
 
     expect(notice.action_taken).to be_nil
   end
@@ -188,14 +188,14 @@ describe Dmca do
   end
 
   context "#redacted" do
-    it "returns '#{Dmca::UNDER_REVIEW_VALUE}' when review is required" do
-      notice = Dmca.new(review_required: true, body: "A value")
+    it "returns '#{DMCA::UNDER_REVIEW_VALUE}' when review is required" do
+      notice = DMCA.new(review_required: true, body: "A value")
 
-      expect(notice.redacted(:body)).to eq Dmca::UNDER_REVIEW_VALUE
+      expect(notice.redacted(:body)).to eq DMCA::UNDER_REVIEW_VALUE
     end
 
     it "returns the actual value when review is not required" do
-      notice = Dmca.new(review_required: false, body: "A value")
+      notice = DMCA.new(review_required: false, body: "A value")
 
       expect(notice.redacted(:body)).to eq "A value"
     end
@@ -203,7 +203,7 @@ describe Dmca do
 
   context "#auto_redact" do
     it "calls RedactsNotices#redact on itself" do
-      notice = Dmca.new
+      notice = DMCA.new
       redactor = RedactsNotices.new
       redactor.should_receive(:redact).with(notice)
       RedactsNotices.should_receive(:new).and_return(redactor)
@@ -276,7 +276,7 @@ describe Dmca do
       create_list(:dmca, 2, review_required: true, reviewer: user)
       create_list(:dmca, 2, review_required: false)
 
-      notices = Dmca.available_for_review
+      notices = DMCA.available_for_review
 
       expect(notices).to match_array(expected_notices)
     end
@@ -286,7 +286,7 @@ describe Dmca do
       create_list(:dmca, 2, review_required: true, spam: true)
       create_list(:dmca, 2, review_required: true, hidden: true)
 
-      notices = Dmca.available_for_review
+      notices = DMCA.available_for_review
 
       expect(notices).to match_array(expected_notices)
 
@@ -301,7 +301,7 @@ describe Dmca do
       )
       create_list(:dmca, 2, review_required: true, reviewer: user_two)
 
-      notices = Dmca.in_review(user_one)
+      notices = DMCA.in_review(user_one)
 
       expect(notices).to match_array(expected_notices)
     end
@@ -315,7 +315,7 @@ describe Dmca do
         @notice_topics.include? t
       end
 
-      notices = Dmca.in_topics(topics)
+      notices = DMCA.in_topics(topics)
 
       expect(notices).to match_array(expected_notices)
     end
@@ -327,7 +327,7 @@ describe Dmca do
       expected_notices = create_list(:dmca, 3, role_names: %w( submitter ))
       submitters = expected_notices.map(&:submitter)
 
-      notices = Dmca.submitted_by(submitters)
+      notices = DMCA.submitted_by(submitters)
 
       expect(notices).to match_array(expected_notices)
     end

--- a/spec/models/entity_notice_role_spec.rb
+++ b/spec/models/entity_notice_role_spec.rb
@@ -76,7 +76,7 @@ describe EntityNoticeRole do
   end
 
   def notice_with_roles_attributes(attributes)
-    Dmca.new(
+    DMCA.new(
       entity_notice_roles_attributes: attributes,
       works: build_list(:work, 2) # to make it valid otherwise
     )

--- a/spec/models/submit_notice_spec.rb
+++ b/spec/models/submit_notice_spec.rb
@@ -3,11 +3,11 @@ require 'spec_helper'
 describe SubmitNotice do
   context "#notice" do
     it "returns a memoized instance" do
-      notice = Dmca.new
-      Dmca.should_receive(:new).once.
+      notice = DMCA.new
+      DMCA.should_receive(:new).once.
         with(attribute: 'value').and_return(notice)
 
-      submit_notice = SubmitNotice.new(Dmca, attribute: 'value')
+      submit_notice = SubmitNotice.new(DMCA, attribute: 'value')
 
       expect(submit_notice.notice).to eq notice
       expect(submit_notice.notice).to eq notice
@@ -16,9 +16,9 @@ describe SubmitNotice do
 
   context "#errors" do
     it "delegates to #notice" do
-      notice = stub_new(Dmca)
+      notice = stub_new(DMCA)
       notice.stub(:errors).and_return(:arbitrary)
-      submit_notice = SubmitNotice.new(Dmca, {})
+      submit_notice = SubmitNotice.new(DMCA, {})
 
       expect(submit_notice.errors).to eq :arbitrary
     end
@@ -27,7 +27,7 @@ describe SubmitNotice do
   context "#submit" do
     context "setting a default title" do
       it "preserves a provided title" do
-        submit_notice = SubmitNotice.new(Dmca, title: "Arbitrary title")
+        submit_notice = SubmitNotice.new(DMCA, title: "Arbitrary title")
 
         submit_notice.submit
 
@@ -36,7 +36,7 @@ describe SubmitNotice do
       end
 
       it "defaults based on type" do
-        [Dmca, Trademark, Other].each do |notice_type|
+        [DMCA, Trademark, Other].each do |notice_type|
           submit_notice = SubmitNotice.new(notice_type, {})
 
           submit_notice.submit
@@ -47,7 +47,7 @@ describe SubmitNotice do
       end
 
       it "defaults based on type and entity when given entity_attributes" do
-        submit_notice = submit_with_roles_attributes(Dmca, [{
+        submit_notice = submit_with_roles_attributes(DMCA, [{
           name: 'recipient', entity_attributes: { name: 'Google' }
         }])
 
@@ -59,7 +59,7 @@ describe SubmitNotice do
 
       it "defaults based on type and entity when given entity_id" do
         entity = create(:entity, name: "Google")
-        submit_notice = submit_with_roles_attributes(Dmca, [{
+        submit_notice = submit_with_roles_attributes(DMCA, [{
           name: 'recipient', entity_id: entity.id
         }])
 
@@ -73,7 +73,7 @@ describe SubmitNotice do
         parameters = HashWithIndifferentAccess.new(
           '0' => { name: 'recipient', entity_attributes: { name: "Google" } }
         )
-        submit_notice = submit_with_roles_attributes(Dmca, parameters)
+        submit_notice = submit_with_roles_attributes(DMCA, parameters)
 
         submit_notice.submit
 
@@ -89,37 +89,37 @@ describe SubmitNotice do
     end
 
     it "auto redacts always" do
-      notice = stub_new(Dmca)
+      notice = stub_new(DMCA)
       notice.should_receive(:auto_redact)
 
-      SubmitNotice.new(Dmca, {}).submit
+      SubmitNotice.new(DMCA, {}).submit
     end
 
     it "returns true and marks for review success" do
-      notice = stub_new(Dmca)
+      notice = stub_new(DMCA)
       notice.stub(:save).and_return(true)
       notice.stub(:copy_id_to_submission_id)
       notice.should_receive(:mark_for_review)
 
-      ret = SubmitNotice.new(Dmca, {}).submit
+      ret = SubmitNotice.new(DMCA, {}).submit
 
       expect(ret).to be_true
     end
 
     it 'copies id to submission_id' do
-      notice = stub_new(Dmca)
+      notice = stub_new(DMCA)
       notice.stub(:save).and_return(true)
       notice.stub(:mark_for_review)
       notice.should_receive(:copy_id_to_submission_id)
 
-      SubmitNotice.new(Dmca, {}).submit
+      SubmitNotice.new(DMCA, {}).submit
     end
 
     it "returns false on failure" do
-      notice = stub_new(Dmca)
+      notice = stub_new(DMCA)
       notice.stub(:save).and_return(false)
 
-      ret = SubmitNotice.new(Dmca, {}).submit
+      ret = SubmitNotice.new(DMCA, {}).submit
 
       expect(ret).to be_false
     end
@@ -128,14 +128,14 @@ describe SubmitNotice do
 
   context "#submit for a user" do
     it "does nothing if the user has no entity" do
-      Dmca.should_receive(:new).with(title: "A title").and_return(null_object)
+      DMCA.should_receive(:new).with(title: "A title").and_return(null_object)
 
-      SubmitNotice.new(Dmca, title: "A title").submit(User.new)
+      SubmitNotice.new(DMCA, title: "A title").submit(User.new)
     end
 
     it "adds entity attributes when user has an entity" do
       user = build(:user, :with_entity)
-      Dmca.should_receive(:new).with(
+      DMCA.should_receive(:new).with(
         title: "A title",
         entity_notice_roles_attributes: [
           { name: 'submitter', entity_id: user.entity.id },
@@ -143,12 +143,12 @@ describe SubmitNotice do
         ]
       ).and_return(null_object)
 
-      SubmitNotice.new(Dmca, title: "A title").submit(user)
+      SubmitNotice.new(DMCA, title: "A title").submit(user)
     end
 
     it "does not affect other roles" do
       user = build(:user, :with_entity)
-      Dmca.should_receive(:new).with(
+      DMCA.should_receive(:new).with(
         entity_notice_roles_attributes: [
           { name: 'sender', entity_attributes: { name: 'Sender' } },
           { name: 'submitter', entity_id: user.entity.id },
@@ -156,21 +156,21 @@ describe SubmitNotice do
         ]
       ).and_return(null_object)
 
-      SubmitNotice.new(Dmca, entity_notice_roles_attributes: [
+      SubmitNotice.new(DMCA, entity_notice_roles_attributes: [
         { name: 'sender', entity_attributes: { name: 'Sender' } }
       ]).submit(user)
     end
 
     it "does not override an explicitly submitted entity" do
       user = build(:user, :with_entity)
-      Dmca.should_receive(:new).with(
+      DMCA.should_receive(:new).with(
         entity_notice_roles_attributes: [
           { name: 'recipient', entity_attributes: { name: 'Recipient' } },
           { name: 'submitter', entity_id: user.entity.id }
         ]
       ).and_return(null_object)
 
-      SubmitNotice.new(Dmca, entity_notice_roles_attributes: [
+      SubmitNotice.new(DMCA, entity_notice_roles_attributes: [
         { name: 'recipient', entity_attributes: { name: 'Recipient' } }
       ]).submit(user)
     end

--- a/spec/models/work_spec.rb
+++ b/spec/models/work_spec.rb
@@ -119,7 +119,7 @@ describe Work do
   private
 
   def notice_with_works_attributes(attributes)
-    Dmca.new(
+    DMCA.new(
       works_attributes: attributes,
       entity_notice_roles_attributes: [{
         name: 'recipient',

--- a/spec/support/notice_actions.rb
+++ b/spec/support/notice_actions.rb
@@ -1,6 +1,6 @@
 module NoticeActions
   def submit_recent_notice(title = "A title")
-    visit "/notices/new?type=Dmca"
+    visit "/notices/new?type=DMCA"
 
     fill_in "Title", with: title
     fill_in "Date received", with: Time.now

--- a/spec/views/notices/new.html.erb_spec.rb
+++ b/spec/views/notices/new.html.erb_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe 'notices/new.html.erb' do
   it "has a form for notices" do
-    assign(:notice, Dmca.new)
+    assign(:notice, DMCA.new)
 
     render
 
@@ -35,7 +35,7 @@ describe 'notices/new.html.erb' do
       second_topic = create(:topic, name: "B Topic")
       third_topic = create(:topic, name: "C Topic")
       first_topic = create(:topic, name: "A Topic")
-      assign(:notice, Dmca.new)
+      assign(:notice, DMCA.new)
 
       render
 


### PR DESCRIPTION
Include rake tasks to up_dmca_migration and down_dmca_migration.
Care should be taken when deploying this. Database entries with type = 'Dmca' will cause errors like:

> LoadError: Expected <RAILS_ROOT>/app/models/dmca.rb to define Dmca

Run `rake chillingeffects:up_dmca_migration` to do an `UPDATE` command changing 'Dmca' to 'DMCA' in the database. The single `UPDATE` might lock the database for too long on production. But without the 'Dmca' to 'DMCA' change, the server is likely to experience the `LoadError` above whenever any 'Dmca' Notices are returned.