### PR TITLE
Tweak migrations to rename url columns instead of replace them.

### DIFF
--- a/db/migrate/20150917014052_add_url_original_to_copyrighted_urls.rb
+++ b/db/migrate/20150917014052_add_url_original_to_copyrighted_urls.rb
@@ -1,16 +1,8 @@
 class AddUrlOriginalToCopyrightedUrls < ActiveRecord::Migration
-  def up
-    add_column t, c, :string, limit: 8192
-    execute "UPDATE #{t} SET #{c} = #{u}"
-    change_column t, c, :string, null: false, limit: 8192
-    remove_index t, u
-    add_index t, c, unique: true
-  end
-
-  def down
-    execute "UPDATE #{t} SET #{u} = #{c}"
-    remove_column t, c
-    add_index t, u, unique: true
+  def change
+    rename_column t, u, c
+    rename_index t, "index_#{t}_on_#{u}", "index_#{t}_on_#{c}"
+    add_column t, u, :string, null: false, limit: 8192
   end
 
   def t

--- a/db/migrate/20150917014352_add_url_original_to_infringing_urls.rb
+++ b/db/migrate/20150917014352_add_url_original_to_infringing_urls.rb
@@ -1,16 +1,8 @@
 class AddUrlOriginalToInfringingUrls < ActiveRecord::Migration
-  def up
-    add_column t, c, :string, limit: 8192
-    execute "UPDATE #{t} SET #{c} = #{u}"
-    change_column t, c, :string, null: false, limit: 8192
-    remove_index t, u
-    add_index t, c, unique: true
-  end
-
-  def down
-    execute "UPDATE #{t} SET #{u} = #{c}"
-    remove_column t, c
-    add_index t, u, unique: true
+  def change
+    rename_column t, u, c
+    rename_index t, "index_#{t}_on_#{u}", "index_#{t}_on_#{c}"
+    add_column t, u, :string, null: false, limit: 8192
   end
 
   def t

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -36,10 +36,10 @@ ActiveRecord::Schema.define(:version => 20150918190529) do
   add_index "blog_entry_topic_assignments", ["topic_id"], :name => "index_blog_entry_topic_assignments_on_topic_id"
 
   create_table "copyrighted_urls", :force => true do |t|
-    t.string   "url",          :limit => 8192, :null => false
+    t.string   "url_original", :limit => 8192, :null => false
     t.datetime "created_at",                   :null => false
     t.datetime "updated_at",                   :null => false
-    t.string   "url_original", :limit => 8192, :null => false
+    t.string   "url",          :limit => 8192, :null => false
   end
 
   add_index "copyrighted_urls", ["url_original"], :name => "index_copyrighted_urls_on_url_original", :unique => true
@@ -106,10 +106,10 @@ ActiveRecord::Schema.define(:version => 20150918190529) do
   add_index "file_uploads", ["notice_id"], :name => "index_file_uploads_on_notice_id"
 
   create_table "infringing_urls", :force => true do |t|
-    t.string   "url",          :limit => 8192, :null => false
+    t.string   "url_original", :limit => 8192, :null => false
     t.datetime "created_at",                   :null => false
     t.datetime "updated_at",                   :null => false
-    t.string   "url_original", :limit => 8192, :null => false
+    t.string   "url",          :limit => 8192, :null => false
   end
 
   add_index "infringing_urls", ["url_original"], :name => "index_infringing_urls_on_url_original", :unique => true

--- a/lib/default_url_original.rb
+++ b/lib/default_url_original.rb
@@ -8,4 +8,13 @@ module DefaultUrlOriginal
   def set_url_original
     self.url_original = url if self.url_original.nil?
   end
+
+  #TODO: Remove this once a copying script has been added and run.
+  def url
+    if super
+      super
+    else
+      url_original
+    end
+  end
 end


### PR DESCRIPTION
Allows us to bring the site back up faster.