### PR TITLE
Move paperclip storage for FileUploads and guard with a controller.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,7 +19,7 @@ tmp/
 .env
 bin/stubs
 coverage/*
-public/system
+paperclip/*
 public/assets
 rerun.txt
 tags

--- a/app/controllers/original_files_controller.rb
+++ b/app/controllers/original_files_controller.rb
@@ -1,0 +1,33 @@
+class OriginalFilesController < ApplicationController
+  def show
+    @upload = FileUpload.where(id: params[:id]).first
+    if params_match? && viewing_allowed?
+      render text: File.read(file_path), content_type: @upload.file_content_type
+    else
+      head :not_found
+    end
+  end
+
+  private
+
+  def file_path
+    @file_path ||= "#{path_params}#{".#{params[:format]}" if params[:format].present?}"
+  end
+
+  def path_params
+    url_params = params[:file_path].split('/').reject { |x| x == '..' }
+    File.join([Rails.root, 'paperclip', 'file_uploads', 'files', url_params].flatten)
+  end
+
+  def viewing_allowed?
+    if @upload.kind == 'original'
+      can?(:access, :original_files)
+    else
+      true
+    end
+  end
+
+  def params_match?
+    @upload && file_path && file_path == @upload.file.path && File.file?(file_path)
+  end
+end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -45,6 +45,7 @@ class Ability
     can :access, :rails_admin
     can :dashboard
     can :search, Entity
+    can :access, :original_files
   end
 
   def grant_redact

--- a/app/models/file_upload.rb
+++ b/app/models/file_upload.rb
@@ -8,7 +8,9 @@ class FileUpload < ActiveRecord::Base
   validates_inclusion_of :kind, in: %w( original supporting )
 
   belongs_to :notice
-  has_attached_file :file
+  has_attached_file :file,
+    path: ":rails_root/paperclip/:class/:attachment/:id_partition/:style/:filename",
+    url: "/:class/:attachment/:id/:id_partition/:style/:filename"
 
   before_save :rename_file, if: ->(instance) { instance.file_name.present? }
   delegate :url, to: :file

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,6 @@
 Chill::Application.routes.draw do
+  get "file_uploads/files/:id/*file_path", to: 'original_files#show'
+
   devise_for :users
 
   mount RailsAdmin::Engine => '/admin', as: 'rails_admin'

--- a/spec/controllers/original_files_controller_spec.rb
+++ b/spec/controllers/original_files_controller_spec.rb
@@ -1,0 +1,19 @@
+require 'spec_helper'
+
+describe OriginalFilesController do
+
+  describe "GET 'show'" do
+    let(:upload) { create(:file_upload) }
+    it "returns not found without valid params" do
+      get 'show', id: upload.id, file_path: ['a', 'b', 'c']
+      expect(response).not_to be_success
+    end
+
+    it "returns http success" do
+      File.stub(:file?).and_return(:true)
+      File.stub(:read).and_return('Content!')
+      expect(response).to be_success
+    end
+  end
+
+end


### PR DESCRIPTION
I experimented with moving the public/support directory on my local machine and did not encounter any errors. I'm not 100% sure how that will work with a server that has ongoing traffic. Might need to disable access to the site until the directory finishes its move then bring it back up with the code changes in place.